### PR TITLE
fix Unhandled rejection ReferenceError

### DIFF
--- a/cypress/integration/fetchAds.js
+++ b/cypress/integration/fetchAds.js
@@ -17,7 +17,7 @@ describe("Extract ads", () => {
               $window.document.removeEventListener("adHpEmotionalLoaded", onAdLoaded)
               resolve()
             }
-            $$window.document.addEventListener("adHpEmotionalLoaded", onAdLoaded, true)
+            $window.document.addEventListener("adHpEmotionalLoaded", onAdLoaded, true)
           })
         }})
         .then(() => {


### PR DESCRIPTION
noticed in https://app.circleci.com/pipelines/github/carforyou/carforyou-ad-data-fetcher/1901/workflows/82c02650-7e75-4b16-8641-3f308f901829/jobs/5130

```
"value": "%cUnhandled rejection ReferenceError: $$window is not defined\n    at eval (https://preprod.*********.ch/__cypress/tests?p=cypress/integration/fetchAds.js:117:13)\n    at Context.onBeforeLoad (https://preprod.*********.ch/__cypress/tests?p=cypress/integration/fetchAds.js:111:18)"
```