### PR TITLE
block launchdarkly

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,7 +5,8 @@
     "*.googletagmanager.com",
     "fonts.googleapis.com",
     "*.criteo.com",
-    "*.criteo.net"
+    "*.criteo.net",
+    "*.launchdarkly.com"
   ],
   "retries": {
     "runMode": 1,


### PR DESCRIPTION
removes unnecessary requests, potentially speeding up the integration tests a tiny bit