### PR TITLE
fix: preserve consent cookie

### DIFF
--- a/cypress/integration/fetchAds.js
+++ b/cypress/integration/fetchAds.js
@@ -5,6 +5,10 @@ describe("Extract ads", () => {
     throw new Error("Please make sure to set CYPRESS_ADS_ENV")
   }
 
+  Cypress.Cookies.defaults({
+    preserve: ["eupubconsent-v2"],
+  })
+
   ;["de", "fr", "it", "en"].forEach((language) => {
     const fileName = `master-${Cypress.env("ADS_ENV")}-${language}-v3.json`
 
@@ -28,7 +32,13 @@ describe("Extract ads", () => {
           })
         },
       }).then(() => {
-        cy.get('button[id="onetrust-accept-btn-handler"]').click()
+        cy.getCookie("eupubconsent-v2").then(cookie => {
+          if(!cookie) {
+            cy.get("#onetrust-banner-sdk").within(() => {
+              cy.get('button[id="onetrust-accept-btn-handler"]').click()
+            })
+          }
+        })
         cy.get("#tatm-adHpEmotional")
         cy.get("div .ad-loaded > #tatm-adHpEmotional[data-ad]", {
           timeout: 20000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       }
     },
     "@types/node": {
-      "version": "14.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-      "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA=="
+      "version": "14.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
+      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
     },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.3",
@@ -390,9 +390,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -657,9 +657,9 @@
       }
     },
     "cypress": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.0.0.tgz",
-      "integrity": "sha512-Hhbc7FtbeCSg5Ui2zxXQLynk7IYGIygG8NqTauS4EtCWyp2k6s4g8P4KUZXwRbhuryN/+/dCd1kPtFbhBx8MuQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.2.0.tgz",
+      "integrity": "sha512-jg7S5VxxslwsgEyAkCE9ZCkFADxOUY1bSWScp1cWnga88K0TZgFQ0zdxyG9Mw/4spLGuvkriIZ62am+TR6C04w==",
       "requires": {
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
@@ -1108,9 +1108,9 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1194,9 +1194,9 @@
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
     },
     "listr2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
-      "integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.11.0.tgz",
+      "integrity": "sha512-XLJVe2JgXCyQTa3FbSv11lkKExYmEyA4jltVo8z4FX10Vt1Yj8IMekBfwim0BSOM9uj1QMTJvDQQpHyuPbB/dQ==",
       "requires": {
         "cli-truncate": "^2.1.0",
         "colorette": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "CAR FOR YOU",
   "license": "MIT",
   "dependencies": {
-    "cypress": "^8.0.0",
+    "cypress": "^8.2.0",
     "cypress-terminal-report": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The pipeline is failing because it cannot find the cookie banner. This change preserves the cookie between the tests and only looks for the banner if the cookie is not set.