### PR TITLE
more predictable approach to closing the cookie banner

### DIFF
--- a/cypress/integration/fetchAds.js
+++ b/cypress/integration/fetchAds.js
@@ -5,13 +5,13 @@ describe("Extract ads", () => {
     throw new Error("Please make sure to set CYPRESS_ADS_ENV")
   }
 
-  Cypress.Cookies.defaults({
-    preserve: ["eupubconsent-v2"],
-  })
   ;["de", "fr", "it", "en"].forEach((language) => {
     const fileName = `master-${Cypress.env("ADS_ENV")}-${language}-v3.json`
 
     it(`${language.toUpperCase()}: Extract and store ad images in json file`, () => {
+      cy.clearCookie("OptanonAlertBoxClosed")
+      cy.clearCookie("eupubconsent-v2")
+
       cy.visit(`/${language}/?visitorId=ads-default&totmdebug=true`, {
         timeout: 20000,
         onBeforeLoad: ($window) => {
@@ -31,23 +31,16 @@ describe("Extract ads", () => {
           })
         },
       }).then(() => {
-        cy.getCookie("eupubconsent-v2").then((cookie) => {
-          if (!cookie) {
-            cy.get("#onetrust-banner-sdk").within(() => {
-              cy.get('button[id="onetrust-accept-btn-handler"]').click()
-            })
-          }
-
-          cy.get("#tatm-adHpEmotional")
-            cy.get("div .ad-loaded > #tatm-adHpEmotional[data-ad]", {
-              timeout: 20000,
-            }).then(($ad) => {
-              const ad =
-                $ad[0].dataset && $ad[0].dataset.ad
-                  ? JSON.parse($ad[0].dataset.ad)
-                  : {}
-              cy.writeFile(`${targetPath}${fileName}`, ad)
-            })
+        cy.get("#onetrust-accept-btn-handler", { timeout: 10000 }).click()
+        cy.get("#tatm-adHpEmotional")
+        cy.get(".ad-loaded > #tatm-adHpEmotional[data-ad]", {
+          timeout: 20000,
+        }).then(($ad) => {
+          const ad =
+            $ad[0].dataset && $ad[0].dataset.ad
+              ? JSON.parse($ad[0].dataset.ad)
+              : {}
+          cy.writeFile(`${targetPath}${fileName}`, ad)
         })
       })
     })


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/carforyou/carforyou-ad-data-fetcher failing often. attempted fix by removing the dependency on the cookie. we moved away from this approach in `content-wider-than-screen`, which is much more stable since. maybe it helps here too. the path is now pretty predictable: 

1. always explicitly clear the cookies (should be the case anyway, but hey...)
2. as the banner is now always shown, we can simply always close the banner without checking for the cookie

maybe comes with a little bit of overhead that could have been saved with the previous approach where the cookie would persist between the test for each language

## How to test

```
npm run debug:prod
```