### PR TITLE
stop notifying slack on fetch failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,6 @@ jobs:
           root: ~/project
           paths:
             - cypress/data
-      - slack/notify-on-failure:
-          only_for_branches: master
 
   fetch_prod:
     <<: *CYPRESS
@@ -90,8 +88,6 @@ jobs:
           root: ~/project
           paths:
             - cypress/data
-      - slack/notify-on-failure:
-          only_for_branches: master
 
   store_preprod:
     <<: *PYTHON


### PR DESCRIPTION
https://autoricardo.atlassian.net/browse/CAR-8731

we have invested a lot of time trying to make this process more stable, but it still fails a couple of times a day. due to the complex and time sensitive nature of this task, we might have to accept that

this PR removes slack notifications for failing the fetch step. instead, we will be monitoring and reporting failures via datadog if they exceed a threshold https://app.datadoghq.com/monitors#51759523/edit