### PR TITLE
only run once a day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
   preprod:
     triggers:
       - schedule:
-          cron: "0 0,2,4,6,8,10,12,14,16,18,20,22 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
let's reduce circleci usage (we're billed by runtime). checking once a day should be enough and manual runs are always available